### PR TITLE
Arreglado bug que causaba que no se pudiera cerrar sesion en edge

### DIFF
--- a/GeneralReservationSystem.Infrastructure/Helpers/JwtHelper.cs
+++ b/GeneralReservationSystem.Infrastructure/Helpers/JwtHelper.cs
@@ -18,6 +18,7 @@ namespace GeneralReservationSystem.Infrastructure.Helpers
     public static class JwtHelper
     {
         public const string CookieName = "jwt_token";
+        public const string CookiePath = "/";
 
         public static SymmetricSecurityKey GetIssuerSigningKeyFromString(string secretKey)
         {
@@ -59,6 +60,7 @@ namespace GeneralReservationSystem.Infrastructure.Helpers
                 Secure = true,
 
                 SameSite = SameSiteMode.None,
+                Path = CookiePath,
 
                 Expires = DateTimeOffset.UtcNow.AddDays(settings.ExpirationDays)
             };
@@ -76,7 +78,15 @@ namespace GeneralReservationSystem.Infrastructure.Helpers
 
         public static void ClearJwtCookie(HttpContext context)
         {
-            context.Response.Cookies.Delete(CookieName);
+            context.Response.Cookies.Delete(CookieName, new()
+            {
+				HttpOnly = true,
+				Secure = true,
+
+				SameSite = SameSiteMode.None,
+
+				Path = CookiePath,
+			});
         }
     }
 }

--- a/GeneralReservationSystem.Infrastructure/Helpers/SessionHelper.cs
+++ b/GeneralReservationSystem.Infrastructure/Helpers/SessionHelper.cs
@@ -10,27 +10,4 @@ namespace GeneralReservationSystem.Infrastructure.Helpers
         public string Email { get; set; } = string.Empty;
         public bool IsAdmin { get; set; }
     }
-
-    public static class SessionHelper
-    {
-        public const string CookieName = "UserSession";
-
-        public static void SetUserSessionCookie(HttpContext context, UserSessionInfo userSession)
-        {
-            CookieOptions options = new()
-            {
-                HttpOnly = true,
-                Secure = true,
-                SameSite = SameSiteMode.Strict,
-                Expires = DateTimeOffset.UtcNow.AddDays(7)
-            };
-            string value = JsonSerializer.Serialize(userSession);
-            context.Response.Cookies.Append(CookieName, value, options);
-        }
-
-        public static void ClearUserSessionCookie(HttpContext context)
-        {
-            context.Response.Cookies.Delete(CookieName);
-        }
-    }
 }


### PR DESCRIPTION
El problema estaba en que no se especificaban los mismos cookie options al eliminar la cookie que al crearla.

De paso borre una clase que ya no se utilizaba en SessionHelpers.